### PR TITLE
Fixes #17, Fixes #18

### DIFF
--- a/src/classes/LeadConvertOverride.cls
+++ b/src/classes/LeadConvertOverride.cls
@@ -40,7 +40,7 @@ public with sharing class LeadConvertOverride {
 
     // properties for page
     public lead l { get; set; }
-    public opportunity dummyOpp { get; set; }
+    public Contact dummyCon { get; set; }
     public boolean sendEmailToOwner { get; set; }
     //public string acct { get; set; }  
     public string con { get; set; }
@@ -64,14 +64,14 @@ public with sharing class LeadConvertOverride {
         l = [select id, name, firstname, lastname, company, email, ownerId from lead
             where id = : controller.getId()];
         
-        // dummy opp allows owner selection
-        dummyOpp = new Opportunity( 
-            ownerid = ((((string)(l.ownerid)).startsWith('005')) ? l.ownerid : userInfo.getUserId())
+        // dummy contact allows owner selection - use contact as always accessible if user has lead conversion rights
+        dummyCon = new Contact(
+            OwnerId = ((((string)(l.ownerid)).startsWith('005')) ? l.ownerid : userInfo.getUserId())
         );
         
         // set a default opp name
         oppName = l.name;
-        doNotCreateOpp = !ContactsSettings.Default_Opp_on_Convert__c;
+        doNotCreateOpp = !Schema.SObjectType.Opportunity.isCreateable() || !ContactsSettings.Default_Opp_on_Convert__c;
         
     }    
     
@@ -134,9 +134,10 @@ public with sharing class LeadConvertOverride {
         // set up the conversion
         Database.LeadConvert lc = new database.LeadConvert();
         lc.setLeadId(l.Id);
-        if (!doNotCreateOpp) lc.setOpportunityName(oppName);
-        lc.setDoNotCreateOpportunity(doNotCreateOpp);
+        if (!doNotCreateOpp && Schema.SObjectType.Opportunity.isCreateable()) lc.setOpportunityName(oppName);
+        lc.setDoNotCreateOpportunity(!Schema.SObjectType.Opportunity.isCreateable() || doNotCreateOpp);
         lc.setConvertedStatus(leadConvStatus);
+        lc.setOwnerId(dummyCon.OwnerId);
         
         // is this a merge to existing?
         if (con != 'NEW_CONTACT') { 
@@ -176,7 +177,7 @@ public with sharing class LeadConvertOverride {
             
             //clean up the extra OCR Issue #214
             // if we create an opp, its a 1x1, and its merged into an existing contact
-            if (!doNotCreateOpp && Constants.isOneToOne() && con != 'NEW_CONTACT'){
+            if (!lc.isDoNotCreateOpportunity() && Constants.isOneToOne() && con != 'NEW_CONTACT'){
                 
                 //get the new OCRs
                 list<OpportunityContactRole> ocrList = [select id, isPrimary, Role from OpportunityContactRole where OpportunityID = :lcr.getOpportunityId() and ContactID = :lcr.getContactId()];

--- a/src/pages/leadConvertOverride.page
+++ b/src/pages/leadConvertOverride.page
@@ -18,7 +18,7 @@
             <apex:pageBlockSection title="Convert Lead" columns="1" collapsible="false">
                 <apex:pageBlockSectionItem >
                     <apex:outputLabel value="Record Owner"/>
-                    <apex:inputField value="{!dummyOpp.OwnerId}"/>
+                    <apex:inputField value="{!dummyCon.OwnerId}"/>
                 </apex:pageBlockSectionItem>
                 <apex:pageBlockSectionItem >
                     <apex:outputLabel value="Send Email to the Owner"/>
@@ -47,7 +47,7 @@
                        </apex:outputPanel> 
                         </apex:outputPanel> 
                 </apex:pageBlockSectionItem>
-                <apex:pageBlockSectionItem >
+                <apex:pageBlockSectionItem rendered="{!$ObjectType.Opportunity.Createable}">
                     <apex:outputLabel value="Opportunity Name"/>
                     <apex:outputPanel >
                         <apex:inputText value="{!oppName}"/><br/>


### PR DESCRIPTION
Respect opportunity access rights on lead conversion.
Allows owner to be set if user cannot access opportunities.
Sets lead owner to that selected in the page.
Hides create opportunity fields in VF page if not applicable.
