### PR TITLE
Contact Merge Page Parameters

### DIFF
--- a/src/classes/ContactMergeController.cls
+++ b/src/classes/ContactMergeController.cls
@@ -34,19 +34,48 @@
 */
 public with sharing class ContactMergeController {
     
-    public ContactMergeController(){
+    //constructor for StandardSetController to allow invocation from list views
+    public ContactMergeController(ApexPages.StandardSetController controller){
         searchText='';
         searchResults = new List<contactWrapper>();
         selectedRecords = new Map<String, Contact>();
-        displaySearchResults = false;
         step = 1;
         fieldRows = new List<FieldRow>();
+        
+        set<Id> mergeIds = new set<Id>();
+        
+    	//if any selected records were passed the standard set controller show the merge page with those records
+    	for(Contact c : (list<Contact>)controller.getSelected()) {
+    		mergeIds.add(c.Id);
+    	}
+    	
+    	if(!mergeIds.isEmpty()) {
+    		loadMergeCandidates(mergeIds);
+    	}
+    	
+    	//otherwise, check for a search parameter for the SOSL query and use that
+    	else if(ApexPages.CurrentPage().getParameters().containsKey('srch')) {
+    		searchText = ApexPages.CurrentPage().getParameters().get('srch');
+    		search();
+    	}
+    	//otherwise, check for a mergeIds parameter, which should contain a comma separated list of Ids to merge
+    	else if(ApexPages.CurrentPage().getParameters().containsKey('mergeIds') && ApexPages.CurrentPage().getParameters().get('mergeIds') != '') {
+    		try {
+    			//attempt to deserialise the comma separated Ids into a list and then a set
+    			mergeIds = new set<Id>((list<Id>)ApexPages.CurrentPage().getParameters().get('mergeIds').split(','));
+    			//if we got any ids, use to try and enter the merge selected records page
+				if (mergeIds != null) {
+					loadMergeCandidates(mergeIds);
+				}
+    		}
+    		catch(StringException e){
+    			ApexPages.addMessages(e);
+    		}
+    	}
     }
     
     private static final String MASTER_KEY = '$MASTER$';
-    
-    public boolean displaySearchResults {get; set;} 
-     
+         
     //string of search text entered by user
     public String searchText { get { return searchText; } set { searchText = value; } }
     
@@ -131,27 +160,31 @@ public with sharing class ContactMergeController {
     // Action method to show the next step of the wizard where user can see the diff of the records before merge
     public void nextStep() {
         
-        String contactIdFilter = ''; // String to create a list of contact Ids to query
-        this.selectedRecordsCount = 0;
+        set<Id> mergeIds = new set<Id>(); 
         for (ContactWrapper c : searchResults) {
             if (c.selected) {
-                contactIdFilter += ('\'' + c.con.Id + '\',');
-                this.selectedRecordsCount++;
+            	mergeIds.add(c.con.Id);
             }
         }
-        contactIdFilter = contactIdFilter.substring(0, contactIdFilter.length() - 1);
+        loadMergeCandidates(mergeIds);
+    }
+    
+    // Action method to show the next step of the wizard where user can see the diff of the records before merge
+	private void loadMergeCandidates(set<Id> mergeCandidates) {
         
         // Check we have atleast 2 and not more than 3 records selected for merge. If not throw an error. 
-        if (this.selectedRecordsCount <=1) {
+        if (mergeCandidates.size() <=1) {
 			ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, Label.Contact_Merge_Error_Too_Few_Contacts));
 			return;
 		}
 		
-		if (this.selectedRecordsCount >3 ) {
+		if (mergeCandidates.size() >3 ) {
 			ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, Label.Contact_Merge_Error_Too_Many_Contacts));
 			return;
 		}
-        
+		
+		selectedRecordsCount = mergeCandidates.size();
+		
         Map<String, Schema.SObjectField> contactFields = Schema.SObjectType.Contact.fields.getMap();
         Map<String, Schema.DescribeFieldResult> standardFieldMap = new Map<String, Schema.DescribeFieldResult>();
         Map<String, Schema.DescribeFieldResult> customFieldMap = new Map<String, Schema.DescribeFieldResult>();
@@ -181,7 +214,7 @@ public with sharing class ContactMergeController {
         // Adding some non-updateable system fields which we need to add to the record diff table.
         query +=  'createdby.name, createddate, LastModifiedBy.name, LastModifiedDate';
         // Finally completing the query by appending the table name and the filter clause
-        query += ' from Contact where id IN (' + contactIdFilter + ')';
+        query += ' from Contact where id IN :mergeCandidates';
         
         System.debug('The contact query is: ' + query);
         
@@ -189,7 +222,7 @@ public with sharing class ContactMergeController {
         try {
             contacts = Database.query(query); // Query the records
             // Ensure we got back the same number of records as expected. In case any record got deleted/moved since last search.
-            if (contacts == null || contacts.size() != this.selectedRecordsCount) {
+            if (contacts == null || contacts.size() != mergeCandidates.size()) {
                 ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, Label.Contact_Merge_Error_Query_Failed + ' ' + Label.Contact_Merge_Error_please_retry));
                 return;
             }
@@ -357,11 +390,7 @@ public with sharing class ContactMergeController {
     public void search() {
         
         if(searchText != null && searchText.length()>0){
-                        
             this.searchResults = wrapSOSLResults(mySOSL());
-            if (searchResults.size() > 0) {
-                displaySearchResults = true;
-            }
         }
     }
     

--- a/src/classes/TEST_ContactMergeController.cls
+++ b/src/classes/TEST_ContactMergeController.cls
@@ -86,14 +86,14 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
 
         controller.searchText = 'test';
         
         controller.search();
         
         //Since we didn't index the results yet, search results should be empty and should not be displayed
-        system.assert(!controller.displaySearchResults);
+        system.assert(controller.searchResults.isEmpty());
 
         Id[] fixedSearchResults=new Id[3]; 
         fixedSearchResults[0]=con.Id; 
@@ -107,7 +107,7 @@ private class TEST_ContactMergeController {
         controller.search();
         
         //search results should be displayed
-        system.assert(controller.displaySearchResults);
+        system.assert(!controller.searchResults.isEmpty());
         
         //there should be 3 Contacts returned
         system.assertEquals(3,controller.searchResults.size());
@@ -199,7 +199,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
 
         controller.searchText = 'test';
         
@@ -270,7 +270,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
 
         controller.searchText = 'test';
         
@@ -325,7 +325,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value      
@@ -405,7 +405,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         
@@ -476,7 +476,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
@@ -544,7 +544,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
@@ -629,7 +629,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
@@ -697,7 +697,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
@@ -762,7 +762,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
@@ -958,7 +958,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
@@ -1038,7 +1038,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
@@ -1115,7 +1115,7 @@ private class TEST_ContactMergeController {
         
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
         
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
@@ -1178,7 +1178,7 @@ private class TEST_ContactMergeController {
         system.assertEquals(con.LastName, 'O\'Sullivan');
                 
         Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
-        ContactMergeController controller = new ContactMergeController();
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
         
         controller.searchText = 'O\'Sullivan';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
@@ -1212,5 +1212,188 @@ private class TEST_ContactMergeController {
     	
     	
     }
+    
+    //check a standard set controller passed into the page is handled correctly
+    static testMethod void testStandardSetSelected(){
+    	
+    	Contacts_and_Orgs_Settings__c contactSettingsForTests = Constants.getContactsSettingsForTests(new Contacts_and_Orgs_Settings__c (Account_Processor__c = Constants.ONE_TO_ONE_PROCESSOR));
+        
+        String newContactMailingStreet = '123 Elm St';
+
+        Contact con = new Contact(
+            FirstName=Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName='O\'Sullivan',
+            MailingStreet = newContactMailingStreet,
+            WorkEmail__c = Constants.CONTACT_EMAIL_FOR_TESTS, 
+            Preferred_Email__c = Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            WorkPhone__c = Constants.CONTACT_PHONE_FOR_TESTS,
+            PreferredPhone__c = Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );        
+        Contact con2 = new Contact(
+            FirstName=Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName='O\'Sullivan',
+            MailingStreet = newContactMailingStreet,
+            WorkEmail__c = Constants.CONTACT_EMAIL_FOR_TESTS, 
+            Preferred_Email__c = Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            WorkPhone__c = Constants.CONTACT_PHONE_FOR_TESTS,
+            PreferredPhone__c = Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );        
+        insert new Contact[]{con, con2};
+                
+        Test.setCurrentPageReference(new PageReference('Page.ContactMerge'));
+        
+        //create standard set controller with 2 records
+        ApexPages.Standardsetcontroller ssc =new ApexPages.Standardsetcontroller(new list<Contact>{con,con2});
+        
+        //select these two records for merge
+        ssc.setSelected(new list<Contact>{con,con2});
+        
+        ContactMergeController controller = new ContactMergeController(ssc);
+        
+        //check we ended up on step 2 of the merge
+        system.assertEquals(2, controller.step); 
+        
+        //check 2 records selected
+        system.assertEquals(2, controller.selectedRecordsCount);
+        
+        //and that fields were populated
+        system.assert(!controller.fieldRows.isEmpty());
+    }
   
+    //check a search term passed into the page is handled correctly
+    static testMethod void testSearchSpecPassed(){
+    	
+    	Contacts_and_Orgs_Settings__c contactSettingsForTests = Constants.getContactsSettingsForTests(new Contacts_and_Orgs_Settings__c (Account_Processor__c = Constants.ONE_TO_ONE_PROCESSOR));
+        
+        String newContactMailingStreet = '123 Elm St';
+
+        Contact con = new Contact(
+            FirstName=Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName='O\'Sullivan',
+            MailingStreet = newContactMailingStreet,
+            WorkEmail__c = Constants.CONTACT_EMAIL_FOR_TESTS, 
+            Preferred_Email__c = Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            WorkPhone__c = Constants.CONTACT_PHONE_FOR_TESTS,
+            PreferredPhone__c = Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );        
+        Contact con2 = new Contact(
+            FirstName=Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName='O\'Sullivan',
+            MailingStreet = newContactMailingStreet,
+            WorkEmail__c = Constants.CONTACT_EMAIL_FOR_TESTS, 
+            Preferred_Email__c = Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            WorkPhone__c = Constants.CONTACT_PHONE_FOR_TESTS,
+            PreferredPhone__c = Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );        
+        insert new Contact[]{con, con2};
+        
+        list<Id> fixedSearchResults = new List<Id>(); 
+        fixedSearchResults.add(con.Id);
+        fixedSearchResults.add(con2.Id);  
+        Test.setFixedSearchResults(fixedSearchResults); 
+        
+        PageReference pr = Page.ContactMerge;
+        pr.getParameters().put('srch', 'O\'Sullivan');
+        
+        Test.setCurrentPageReference(pr);
+        
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
+        
+        //check we ended up on step 1 of the merge
+        system.assertEquals(1, controller.step); 
+        
+        //check the 2 records already retrieved in search results
+        system.assertEquals(2, controller.searchResults.size());
+    }
+    
+    //check a comma separated list of Ids are handled correctly
+    static testMethod void testGoodIdsPassed(){
+    	
+    	Contacts_and_Orgs_Settings__c contactSettingsForTests = Constants.getContactsSettingsForTests(new Contacts_and_Orgs_Settings__c (Account_Processor__c = Constants.ONE_TO_ONE_PROCESSOR));
+        
+        String newContactMailingStreet = '123 Elm St';
+
+        Contact con = new Contact(
+            FirstName=Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName='O\'Sullivan',
+            MailingStreet = newContactMailingStreet,
+            WorkEmail__c = Constants.CONTACT_EMAIL_FOR_TESTS, 
+            Preferred_Email__c = Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            WorkPhone__c = Constants.CONTACT_PHONE_FOR_TESTS,
+            PreferredPhone__c = Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );        
+        Contact con2 = new Contact(
+            FirstName=Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName='O\'Sullivan',
+            MailingStreet = newContactMailingStreet,
+            WorkEmail__c = Constants.CONTACT_EMAIL_FOR_TESTS, 
+            Preferred_Email__c = Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            WorkPhone__c = Constants.CONTACT_PHONE_FOR_TESTS,
+            PreferredPhone__c = Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );        
+        insert new Contact[]{con, con2};
+        
+        PageReference pr = Page.ContactMerge;
+        pr.getParameters().put('mergeIds', con.Id + ',' + con2.Id);
+        
+        Test.setCurrentPageReference(pr);
+        
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
+        
+        //check we ended up on step 2 of the merge
+        system.assertEquals(2, controller.step); 
+        
+        //check 2 records selected
+        system.assertEquals(2, controller.selectedRecordsCount);
+        
+        //and that fields were populated
+        system.assert(!controller.fieldRows.isEmpty());
+    }
+    
+    //check invalid Ids are handled
+    static testMethod void testBadIdsPassed(){
+    	
+    	Contacts_and_Orgs_Settings__c contactSettingsForTests = Constants.getContactsSettingsForTests(new Contacts_and_Orgs_Settings__c (Account_Processor__c = Constants.ONE_TO_ONE_PROCESSOR));
+        
+        String newContactMailingStreet = '123 Elm St';
+
+        Contact con = new Contact(
+            FirstName=Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName='O\'Sullivan',
+            MailingStreet = newContactMailingStreet,
+            WorkEmail__c = Constants.CONTACT_EMAIL_FOR_TESTS, 
+            Preferred_Email__c = Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            WorkPhone__c = Constants.CONTACT_PHONE_FOR_TESTS,
+            PreferredPhone__c = Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );        
+        Contact con2 = new Contact(
+            FirstName=Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName='O\'Sullivan',
+            MailingStreet = newContactMailingStreet,
+            WorkEmail__c = Constants.CONTACT_EMAIL_FOR_TESTS, 
+            Preferred_Email__c = Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            WorkPhone__c = Constants.CONTACT_PHONE_FOR_TESTS,
+            PreferredPhone__c = Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );        
+        insert new Contact[]{con, con2};
+        
+        list<Id> fixedSearchResults = new List<Id>(); 
+        fixedSearchResults.add(con.Id);
+        fixedSearchResults.add(con2.Id);  
+        Test.setFixedSearchResults(fixedSearchResults); 
+        
+        PageReference pr = Page.ContactMerge;
+        pr.getParameters().put('mergeIds', 'blah');
+        
+        Test.setCurrentPageReference(pr);
+        
+        ContactMergeController controller = new ContactMergeController(new ApexPages.Standardsetcontroller(new list<Contact>()));
+        
+        //check we ended up on step 1 of the merge
+        system.assertEquals(1, controller.step); 
+        
+        //check error message logged to the page
+        system.assert(ApexPages.hasMessages()); 
+        
+    }
 }

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -406,4 +406,16 @@ if(ISPICKVAL(Secondary_Address_Type__c,&quot;Work&quot;),
         </filters>
         <label>New This Week</label>
     </listViews>
+    <webLinks>
+        <fullName>Merge_Contacts</fullName>
+        <availability>online</availability>
+        <displayType>massActionButton</displayType>
+        <height>600</height>
+        <linkType>page</linkType>
+        <masterLabel>Merge Contacts</masterLabel>
+        <openType>sidebar</openType>
+        <page>ContactMerge</page>
+        <protected>false</protected>
+        <requireRowSelection>true</requireRowSelection>
+    </webLinks>
 </CustomObject>

--- a/src/pages/ContactMerge.page
+++ b/src/pages/ContactMerge.page
@@ -1,4 +1,4 @@
-<apex:page controller="ContactMergeController" title="Merge Contacts" id="contactMergePage">
+<apex:page standardController="Contact" extensions="ContactMergeController" title="Merge Contacts" id="contactMergePage" tabStyle="Contact_Merge__tab" recordSetVar="cons" >
 
     <style type="text/css">
         .mergeTable{
@@ -63,11 +63,11 @@
         
         <apex:pageMessages /> 
         <apex:outputPanel id="searchresults" layout="block">
-            <apex:outputPanel id="nothingfound" layout="block" rendered="{!!displaySearchResults&&searchText!=''}">
+            <apex:outputPanel id="nothingfound" layout="block" rendered="{!searchResults.size = 0}">
             {!$Label.Contact_Merge_Error_Confirm_Message_Nothing_Found}
             </apex:outputPanel>
             <apex:form >
-                <apex:pageBlock title="Found Contacts" rendered="{!displaySearchResults}"> 
+                <apex:pageBlock title="Found Contacts" rendered="{!searchResults.size > 0}"> 
                     <apex:pageBlockTable value="{!searchResults}" var="item">
                         <apex:column >
                             <apex:inputCheckbox value="{!item.selected}" id="checkedone"/>

--- a/src/pages/ContactMerge.page
+++ b/src/pages/ContactMerge.page
@@ -63,7 +63,7 @@
         
         <apex:pageMessages /> 
         <apex:outputPanel id="searchresults" layout="block">
-            <apex:outputPanel id="nothingfound" layout="block" rendered="{!searchResults.size = 0}">
+            <apex:outputPanel id="nothingfound" layout="block" rendered="{!searchResults.size = 0 && searchText!=''}">
             {!$Label.Contact_Merge_Error_Confirm_Message_Nothing_Found}
             </apex:outputPanel>
             <apex:form >


### PR DESCRIPTION
Closes #21
Ability to associate merge page with Contact list views, and pass
selected contacts in via standardsetcontroller functionality.
Ability to pass search term as a parameter, e.g.
&srch=James
Ability to pass list of Ids parameter, e.g.
&mergeIds=003000000000001,003000000000002,003000000000003
Also:
Show appropriate section header when page loaded without clicking tab
