### PR TITLE
Activate email/phone workflow rules initially

### DIFF
--- a/src/workflows/Contact.workflow
+++ b/src/workflows/Contact.workflow
@@ -164,7 +164,7 @@ OtherPhone
             <name>ContactAlternateEmailUpdate</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <formula>AND(      ISPICKVAL( Preferred_Email__c ,&quot;Alternate&quot;),      OR(           AND(                ISNEW(),                LEN(Email)&gt;0           ),           ISCHANGED( Email )      ) )</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>
@@ -174,7 +174,7 @@ OtherPhone
             <name>ContactPersonalEmailUpdate</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <formula>AND(     OR( ISPICKVAL( Preferred_Email__c ,&quot;Personal&quot;),ISPICKVAL( Preferred_Email__c ,&quot;Home&quot;)),      OR(           AND(                ISNEW(),                LEN(Email)&gt;0           ),           ISCHANGED( Email )      ) )</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>
@@ -184,7 +184,7 @@ OtherPhone
             <name>ContactWorkEmailUpdate</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <formula>AND(      ISPICKVAL( Preferred_Email__c ,&quot;Work&quot;),      OR(           AND(                ISNEW(),                LEN(Email)&gt;0           ),           ISCHANGED( Email )      ) )</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>
@@ -194,7 +194,7 @@ OtherPhone
             <name>ContactHomePhoneUpdate</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <formula>AND(      ISPICKVAL( PreferredPhone__c ,&quot;Home&quot;),      OR(           AND(                ISNEW(),                LEN(Phone)&gt;0           ),           ISCHANGED( Phone )      ) )</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>
@@ -204,7 +204,7 @@ OtherPhone
             <name>ContactMobilePhoneUpdate</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <formula>AND(      ISPICKVAL( PreferredPhone__c ,&quot;Mobile&quot;),      OR(           AND(                ISNEW(),                LEN(Phone)&gt;0           ),           ISCHANGED( Phone )      ) )</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>
@@ -214,7 +214,7 @@ OtherPhone
             <name>ContactOtherEmailUpdate</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <formula>AND(      ISPICKVAL( PreferredPhone__c ,&quot;Other&quot;),      OR(           AND(                ISNEW(),                LEN(Phone)&gt;0           ),           ISCHANGED( Phone )      ) )</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>
@@ -224,7 +224,7 @@ OtherPhone
             <name>ContactWorkPhoneUpdate</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <formula>AND(      ISPICKVAL( PreferredPhone__c ,&quot;Work&quot;),      OR(           AND(                ISNEW(),                LEN(Phone)&gt;0           ),           ISCHANGED( Phone )      ) )</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>
@@ -234,7 +234,7 @@ OtherPhone
             <name>ContactPreferredEmail</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <description>This workflow OVERWRITES the existing value in the standard Email field based on the Preferred Email field value.  This rule needs to be turned on manually after an Upgrade to this package.</description>
         <formula>OR( LEN(Email)=0, ISCHANGED(Preferred_Email__c) , ISCHANGED(WorkEmail__c) , ISCHANGED(HomeEmail__c) , ISCHANGED(AlternateEmail__c)  )</formula>
         <triggerType>onAllChanges</triggerType>
@@ -245,7 +245,7 @@ OtherPhone
             <name>ContactPreferredPhone</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <description>This workflow OVERWRITES the existing value in the standard Phone field based on the Preferred Phone field value.  This rule needs to be turned on manually after an Upgrade to this package.</description>
         <formula>OR(  LEN(Phone)=0, ISCHANGED(PreferredPhone__c) ,  ISCHANGED(WorkPhone__c) ,  ISCHANGED(HomePhone) ,  ISCHANGED(MobilePhone) , ISCHANGED(OtherPhone)  )</formula>
         <triggerType>onAllChanges</triggerType>
@@ -260,7 +260,7 @@ OtherPhone
             <name>SetWorkEmailtoEmail</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <criteriaItems>
             <field>Contact.Email</field>
             <operation>notEqual</operation>
@@ -294,7 +294,7 @@ OtherPhone
             <name>WorkPhonetoPhone</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>false</active>
+        <active>true</active>
         <booleanFilter>1 AND 2 AND 3 AND 4 AND 5 AND 6</booleanFilter>
         <criteriaItems>
             <field>Contact.Phone</field>


### PR DESCRIPTION
# Critical Changes

# Changes
The workflow rules for contact email and phone fields are now activated by default for new installations, to match how they are configured in the trial experience.

# Issues Closed
