### PR TITLE
Fix uninstall_packaged_incremental

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -7,12 +7,9 @@ project:
     git:
         prefix_release: rel/
 
-flows:
-    deploy_unmanaged:
-        steps:
-            4:
-                task: None
-    deploy_packaging:
-        steps:
-            6:
-                task: None
+tasks:
+    uninstall_packaged_incremental:
+        options:
+            ignore:
+                ListView:
+                    Payment_Field_Mapping_Settings__c.All


### PR DESCRIPTION
Now skipping deletion of a ListView that can't be deleted (b/c it's the object's last list view) instead of skipping uninstall_packaged_incremental altogether.

# Critical Changes

# Changes

# Issues Closed
