### PR TITLE
Deprecating the "Nonprofit Edition Reports" weblink

### DIFF
--- a/src/weblinks/Nonprofit_Edition_Reports.weblink
+++ b/src/weblinks/Nonprofit_Edition_Reports.weblink
@@ -3,7 +3,7 @@
     <availability>online</availability>
     <displayType>link</displayType>
     <linkType>javascript</linkType>
-    <masterLabel>Nonprofit Edition Reports</masterLabel>
+    <masterLabel>DEPRECATED: Nonprofit Edition Reports</masterLabel>
     <openType>onClickJavaScript</openType>
     <protected>false</protected>
     <url>{!REQUIRESCRIPT(&quot;/soap/ajax/13.0/connection.js&quot;)}


### PR DESCRIPTION
# Critical Changes

# Changes

- Deprecate the "Nonprofit Edition Reports" weblink label because inline Javascript is no longer supported. The weblink itself will be removed in a future release.

# Issues Closed
