### PR TITLE
Add a payment method of Paypal to OppPayment__c.object

### DIFF
--- a/src/objects/OppPayment__c.object
+++ b/src/objects/OppPayment__c.object
@@ -137,7 +137,7 @@
                 <default>false</default>
             </picklistValues>
             <picklistValues>
-                <fullName>Paypal</fullName>
+                <fullName>PayPal</fullName>
                 <default>false</default>
             </picklistValues>
             <sorted>false</sorted>

--- a/src/objects/OppPayment__c.object
+++ b/src/objects/OppPayment__c.object
@@ -136,6 +136,10 @@
                 <fullName>ACH</fullName>
                 <default>false</default>
             </picklistValues>
+            <picklistValues>
+                <fullName>Paypal</fullName>
+                <default>false</default>
+            </picklistValues>
             <sorted>false</sorted>
         </picklist>
         <required>false</required>


### PR DESCRIPTION
# Critical Changes

# Changes
 - We added `PayPal` as a picklist value to the Payment Method field (on the Payment object) to support PayPal as a payment method in Elevate.
 
# Issues Closed
